### PR TITLE
Fix bug in p5 0.4.11+

### DIFF
--- a/p5.pdf.js
+++ b/p5.pdf.js
@@ -91,8 +91,8 @@
       * Will return a clone of current SVG element
       */
      PDF.prototype.__snapshot = function() {
-         var graphics = this.p5Instance._graphics;
-         var elt = graphics.isSVG ? graphics.svg : graphics.elt;
+         var renderer = this.p5Instance._renderer || this.p5Instance._graphics;
+         var elt = renderer.isSVG ? renderer.svg : renderer.elt;
          var snapshot = elt.cloneNode(true);
          if (elt.nodeName.toLowerCase() === 'canvas') {
              // for canvas, also copy its content


### PR DESCRIPTION
It seems that p5's internal reference to the renderer was changed from `_graphics` to `_renderer` in commit c251b8211231c78068a259952417ec610adab856 (0.4.11). Now the PDF module will check for both.
